### PR TITLE
Fix Data Acquisition for Magnetometer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ set(PROJECT_SOURCES
     Src/Logger/Logger.cpp
     # Sensor Implementations
     Src/Sensors/SensorsRegistry.cpp
-    Src/Sensors/LSM9DS1_ImuSens.cpp
+    Src/Sensors/LSM9DS1_ImuSensAccGyro.cpp
+    Src/Sensors/LSM9DS1_ImuSensMag.cpp
     Src/Sensors/LPS25HB_EnvSens.cpp
     # Utility Functions
     Src/Utils/Utils.cpp

--- a/Include/EdgeSense/Core/ThreadManager.h
+++ b/Include/EdgeSense/Core/ThreadManager.h
@@ -17,6 +17,11 @@ namespace EdgeSense {
 
     enum class Tier { Harvester, Refiner, Navigator };
 
+    /* Using slow sampling rates instead of the desired ones (1/5/10) => (5/25/50) */
+    #define HARVESTER_CYCLETIME_MS 5
+    #define REFINER_CYCLETIME_MS 25
+    #define NAVIGATOR_CYCLETIME_MS 50
+
     class ThreadManager {
         public:
         /* Define the function signatures for our three tiers */

--- a/Include/EdgeSense/Sensors/LPS25HB_EnvSens.h
+++ b/Include/EdgeSense/Sensors/LPS25HB_EnvSens.h
@@ -11,7 +11,7 @@
 
 namespace EdgeSense {
     namespace Sensors {
-        class LPS25HB : public EnvSensor {
+        class LPS25HB : public EnvSensors {
         public:
             LPS25HB(HAL::I2cMaster& bus);
             

--- a/Include/EdgeSense/Sensors/LSM9DS1_ImuSensAccGyro.h
+++ b/Include/EdgeSense/Sensors/LSM9DS1_ImuSensAccGyro.h
@@ -1,0 +1,33 @@
+/**
+ * @file LSM9DS1_ImuSensAccGyro.h
+ * @author Hedi Basly
+ * @brief Header for LSM9DS1 ImuSensor module for Accelerometer and Gyroscope
+ * @date 2026-02-16
+ */
+#pragma once
+
+#include "EdgeSense/Sensors/Sensors.h"
+
+namespace EdgeSense {
+    namespace Sensors {
+
+        class LSM9DS1_AccGyro : public ImuSensor {
+        public:
+            LSM9DS1_AccGyro(HAL::I2cMaster& bus);
+            
+            bool initialize() override;
+            void update() override;
+            Vector3 getAcceleration() const override;
+            Vector3 getGyroscope() const override;
+
+        private:
+            Vector3 accel;
+            Vector3 gyro;
+            Vector3 magneto;
+
+            // Helper to combine high/low bytes into a signed 16-bit integer
+            int16_t stitch(uint8_t low, uint8_t high) const;
+        };
+
+    } // namespace Sensors
+} // namespace EdgeSense

--- a/Include/EdgeSense/Sensors/LSM9DS1_ImuSensAccGyro.h
+++ b/Include/EdgeSense/Sensors/LSM9DS1_ImuSensAccGyro.h
@@ -11,7 +11,7 @@
 namespace EdgeSense {
     namespace Sensors {
 
-        class LSM9DS1_AccGyro : public ImuSensor {
+        class LSM9DS1_AccGyro : public ImuSensors {
         public:
             LSM9DS1_AccGyro(HAL::I2cMaster& bus);
             

--- a/Include/EdgeSense/Sensors/LSM9DS1_ImuSensMag.h
+++ b/Include/EdgeSense/Sensors/LSM9DS1_ImuSensMag.h
@@ -1,7 +1,7 @@
 /**
- * @file LSM9DS1_ImuSens.h
+ * @file LSM9DS1_ImuSensMag.h
  * @author Hedi Basly
- * @brief Header for LSM9DS1 ImuSensor module
+ * @brief Header for LSM9DS1 ImuSensor module for Magnetometer
  * @date 2026-02-16
  */
 #pragma once
@@ -11,19 +11,15 @@
 namespace EdgeSense {
     namespace Sensors {
 
-        class LSM9DS1 : public ImuSensor {
+        class LSM9DS1_Mag : public ImuSensor {
         public:
-            LSM9DS1 (HAL::I2cMaster& bus);
+            LSM9DS1_Mag(HAL::I2cMaster& bus);
             
             bool initialize() override;
             void update() override;
-            Vector3 getAcceleration() const override;
-            Vector3 getGyroscope() const override;
             Vector3 getMagnetometer() const override;
 
         private:
-            Vector3 accel;
-            Vector3 gyro;
             Vector3 magneto;
 
             // Helper to combine high/low bytes into a signed 16-bit integer

--- a/Include/EdgeSense/Sensors/LSM9DS1_ImuSensMag.h
+++ b/Include/EdgeSense/Sensors/LSM9DS1_ImuSensMag.h
@@ -11,7 +11,7 @@
 namespace EdgeSense {
     namespace Sensors {
 
-        class LSM9DS1_Mag : public ImuSensor {
+        class LSM9DS1_Mag : public ImuSensors {
         public:
             LSM9DS1_Mag(HAL::I2cMaster& bus);
             

--- a/Include/EdgeSense/Sensors/Sensors.h
+++ b/Include/EdgeSense/Sensors/Sensors.h
@@ -43,7 +43,7 @@ namespace EdgeSense {
         /**
          * @brief Middle-layer for Environmental Data
          */
-        class EnvSensor : public Sensor {
+        class EnvSensors : public Sensor {
         public:
             using Sensor::Sensor; 
             
@@ -62,7 +62,7 @@ namespace EdgeSense {
             float z = 0.0f;
         };
 
-        class ImuSensor : public Sensor {
+        class ImuSensors : public Sensor {
         public:
             using Sensor::Sensor;
 

--- a/Src/Core/ThreadManager.cpp
+++ b/Src/Core/ThreadManager.cpp
@@ -43,7 +43,7 @@ namespace EdgeSense {
         clock_gettime(CLOCK_MONOTONIC, &next_time);
 
         while (running) {
-            next_time.tv_nsec += 1000000; /* 1ms */
+            next_time.tv_nsec += HARVESTER_CYCLETIME_MS * 1000000; /* 10ms */
             if (next_time.tv_nsec >= 1000000000) {
                 next_time.tv_nsec -= 1000000000;
                 next_time.tv_sec++;
@@ -71,7 +71,7 @@ namespace EdgeSense {
         clock_gettime(CLOCK_MONOTONIC, &next_time);
 
         while (running) {
-            next_time.tv_nsec += 5000000; /* 5ms */
+            next_time.tv_nsec += REFINER_CYCLETIME_MS * 1000000;; /* 50ms */
             if (next_time.tv_nsec >= 1000000000) {
                 next_time.tv_nsec -= 1000000000;
                 next_time.tv_sec++;
@@ -99,7 +99,7 @@ namespace EdgeSense {
         clock_gettime(CLOCK_MONOTONIC, &next_time);
 
         while (running) {
-            next_time.tv_nsec += 10000000; /* 10ms */
+            next_time.tv_nsec += NAVIGATOR_CYCLETIME_MS * 1000000;; /* 100ms */
             if (next_time.tv_nsec >= 1000000000) {
                 next_time.tv_nsec -= 1000000000;
                 next_time.tv_sec++;

--- a/Src/Sensors/LPS25HB_EnvSens.cpp
+++ b/Src/Sensors/LPS25HB_EnvSens.cpp
@@ -12,7 +12,7 @@
 namespace EdgeSense {
     namespace Sensors {
         LPS25HB::LPS25HB(HAL::I2cMaster& bus) 
-        : EnvSensor("LPS25HB", 0x5C, bus), temp(0.0f), pressure(0.0f) {}
+        : EnvSensors("LPS25HB", 0x5C, bus), temp(0.0f), pressure(0.0f) {}
 
         bool LPS25HB::initialize() {
             uint8_t id = 0;

--- a/Src/Sensors/LSM9DS1_ImuSensAccGyro.cpp
+++ b/Src/Sensors/LSM9DS1_ImuSensAccGyro.cpp
@@ -16,7 +16,7 @@
 
 namespace EdgeSense {
     namespace Sensors {
-        LSM9DS1_AccGyro::LSM9DS1_AccGyro(HAL::I2cMaster& bus) : ImuSensor("Accel-Gyro", 0x6A, bus), 
+        LSM9DS1_AccGyro::LSM9DS1_AccGyro(HAL::I2cMaster& bus) : ImuSensors("Accel-Gyro", 0x6A, bus), 
             accel({0.0f, 0.0f, 0.0f}), 
             gyro({0.0f, 0.0f, 0.0f}) {}
 

--- a/Src/Sensors/LSM9DS1_ImuSensAccGyro.cpp
+++ b/Src/Sensors/LSM9DS1_ImuSensAccGyro.cpp
@@ -1,23 +1,28 @@
 /**
- * @file LSM9DS1_ImuSens.cpp
+ * @file LSM9DS1_ImuSensAccGyro.cpp
  * @author Hedi Basly
- * @brief Implementation of LSM9DS1 ImuSensor module
+ * @brief Implementation of LSM9DS1 ImuSensor module for Accelerometer and Gyroscope
+  * This module provides the implementation for interfacing with the LSM9DS1 IMU sensor, specifically
+  * for reading acceleration and gyroscope data. It includes:
+  * - Initialization of the sensor with appropriate configuration settings for both accelerometer and gyroscope.
+  * - An update method that reads raw data from the sensor registers, converts it to physical units (g for accel, dps for gyro), and stores it in member variables.
+  * - A helper method `stitch` to combine high and low bytes into a signed 16-bit integer, which is necessary for interpreting the raw sensor data correctly.
  * @date 2026-02-16
  */
 
 #include "EdgeSense/Sensors/Sensors.h"
-#include "EdgeSense/Sensors/LSM9DS1_ImuSens.h"
+#include "EdgeSense/Sensors/LSM9DS1_ImuSensAccGyro.h"
 #include "EdgeSense/Logger/Logger.h"
 
 namespace EdgeSense {
     namespace Sensors {
-        LSM9DS1::LSM9DS1(HAL::I2cMaster& bus) : ImuSensor("Accel-Gyro", 0x6A, bus), 
+        LSM9DS1_AccGyro::LSM9DS1_AccGyro(HAL::I2cMaster& bus) : ImuSensor("Accel-Gyro", 0x6A, bus), 
             accel({0.0f, 0.0f, 0.0f}), 
             gyro({0.0f, 0.0f, 0.0f}) {}
 
-        bool LSM9DS1::initialize() {
+        bool LSM9DS1_AccGyro::initialize() {
             uint8_t id = 0;
-            bool configresVal = false;
+            bool configresVal = true;
             bool retVal = true;
             
             // 1. Verify WHO_AM_I (Register 0x0F)
@@ -30,21 +35,21 @@ namespace EdgeSense {
             // 0x44 = [0][1][0][0][0][1][0][0]
             // Bit 6: BDU (Block Data Update) - Wait for all bytes to be read
             // Bit 2: IF_ADD_INC - Auto-increment register address during multi-byte reads
-            configresVal = i2cBus.writeByte(address, 0x22, 0x44);
+            configresVal &= i2cBus.writeByte(address, 0x22, 0x44);
 
             // 3. Gyroscope Setup (CTRL_REG1_G @ 0x10)
             // 0x60 = 119 Hz ODR, 245 dps Full Scale
-            configresVal = i2cBus.writeByte(address, 0x10, 0x60);
+            configresVal &= i2cBus.writeByte(address, 0x10, 0x60);
             
             // Enable Gyro axes (CTRL_REG4 @ 0x1E)
-            configresVal = i2cBus.writeByte(address, 0x1E, 0x38);
+            configresVal &= i2cBus.writeByte(address, 0x1E, 0x38);
 
             // 4. Accelerometer Setup (CTRL_REG6_XL @ 0x20)
             // 0x60 = 119 Hz ODR, +/- 2g Full Scale
-            configresVal = i2cBus.writeByte(address, 0x20, 0x60);
+            configresVal &= i2cBus.writeByte(address, 0x20, 0x60);
 
             // Enable Accel axes (CTRL_REG5_XL @ 0x1F)
-            configresVal = i2cBus.writeByte(address, 0x1F, 0x38);
+            configresVal &= i2cBus.writeByte(address, 0x1F, 0x38);
 
             if (!configresVal) {
                 LOG_ERROR(name + ": Failed to write configuration.");
@@ -55,7 +60,7 @@ namespace EdgeSense {
             return retVal;
         }
 
-        void LSM9DS1::update() {
+        void LSM9DS1_AccGyro::update() {
             uint8_t buf[6];
 
             /* Read Accel (6 bytes starting at 0x28) */
@@ -74,12 +79,11 @@ namespace EdgeSense {
             }
         }
 
-        int16_t LSM9DS1::stitch(uint8_t low, uint8_t high) const {
+        int16_t LSM9DS1_AccGyro::stitch(uint8_t low, uint8_t high) const {
             return static_cast<int16_t>((high << 8) | low);
         }
 
-        Vector3 LSM9DS1::getAcceleration() const { return accel; }
-        Vector3 LSM9DS1::getGyroscope() const { return gyro; }
-        Vector3 LSM9DS1::getMagnetometer() const { return magneto; } 
+        Vector3 LSM9DS1_AccGyro::getAcceleration() const { return accel; }
+        Vector3 LSM9DS1_AccGyro::getGyroscope() const { return gyro; }
     } /* namespace Sensors */
 } /* namespace EdgeSense */

--- a/Src/Sensors/LSM9DS1_ImuSensMag.cpp
+++ b/Src/Sensors/LSM9DS1_ImuSensMag.cpp
@@ -16,7 +16,7 @@
 
 namespace EdgeSense {
     namespace Sensors {
-        LSM9DS1_Mag::LSM9DS1_Mag(HAL::I2cMaster& bus) : ImuSensor("Magneto", 0x1C, bus), 
+        LSM9DS1_Mag::LSM9DS1_Mag(HAL::I2cMaster& bus) : ImuSensors("Magneto", 0x1C, bus), 
             magneto({0.0f, 0.0f, 0.0f}) {}
 
         bool LSM9DS1_Mag::initialize() {

--- a/Src/Sensors/LSM9DS1_ImuSensMag.cpp
+++ b/Src/Sensors/LSM9DS1_ImuSensMag.cpp
@@ -1,0 +1,80 @@
+/**
+ * @file LSM9DS1_ImuSensMag.cpp
+ * @author Hedi Basly
+ * @brief Implementation of LSM9DS1 ImuSensor module for Magnetometer
+  * This module provides the implementation for interfacing with the LSM9DS1 IMU sensor, specifically
+  * for reading magnetometer data. It includes:
+  * - Initialization of the sensor with appropriate configuration settings for the magnetometer.
+  * - An update method that reads raw data from the sensor registers, converts it to physical units (Ga), and stores it in a member variable.
+  * - A helper method `stitch` to combine high and low bytes into a signed 16-bit integer, which is necessary for interpreting the raw sensor data correctly.
+ * @date 2026-02-16
+ */
+
+#include "EdgeSense/Sensors/Sensors.h"
+#include "EdgeSense/Sensors/LSM9DS1_ImuSensMag.h"
+#include "EdgeSense/Logger/Logger.h"
+
+namespace EdgeSense {
+    namespace Sensors {
+        LSM9DS1_Mag::LSM9DS1_Mag(HAL::I2cMaster& bus) : ImuSensor("Magneto", 0x1C, bus), 
+            magneto({0.0f, 0.0f, 0.0f}) {}
+
+        bool LSM9DS1_Mag::initialize() {
+            uint8_t id = 0;
+            bool configresVal = true;
+            bool retVal = true;
+            
+            // 1. Verify WHO_AM_I (Register 0x0F)
+            if (!i2cBus.readByte(address, 0x0F, id) || id != 0x3D) {
+                LOG_ERROR(name + ": ID Mismatch. Expected 0x3D, got 0x" + std::to_string(id));
+                retVal = false;
+            }
+
+            /* 2. Set X/Y to Ultra-High Performance and ODR to 80Hz */
+            /* 0x7C = 0111 1100 in binary */
+            configresVal &= i2cBus.writeByte(address, 0x20, 0x7C);
+
+            /* 3. Set Full Scale to +/- 4 Gauss */
+            configresVal &= i2cBus.writeByte(address, 0x21, 0x00);
+
+            /* 4. Enable Continuous Conversion Mode (Wake up!) */
+            configresVal &= i2cBus.writeByte(address, 0x22, 0x00);
+
+            /* 5. Set Z to Ultra-High Performance */
+            configresVal &= i2cBus.writeByte(address, 0x23, 0x0C);
+
+            /* 6. Block Data Update (BDU) */
+            /* Register 0x24 bit 6 ensures we don't read MSB and LSB from different samples */
+            configresVal &= i2cBus.writeByte(address, 0x24, 0x40);
+
+            if (!configresVal) {
+                LOG_ERROR(name + ": Failed to write configuration.");
+                retVal = false;
+            }
+
+            LOG_INFO(name + ": Magnetometer initialized successfully.");
+            return retVal;
+        }
+
+        void LSM9DS1_Mag::update() {
+            uint8_t buf[6];
+
+            /* Read Mag (6 bytes starting at 0x28) */
+            /* We use the 0x80 bit for auto-incrementing the register address */
+            if (i2cBus.readBytes(address, 0x28 | 0x80, buf, 6)) {
+                /* Sensitivity for +/- 4 Gauss is 0.14 mG/LSB */
+                magneto.x = stitch(buf[0], buf[1]) * 0.00014f;
+                magneto.y = stitch(buf[2], buf[3]) * 0.00014f;
+                magneto.z = stitch(buf[4], buf[5]) * 0.00014f;
+            } else {
+                LOG_ERROR(name + ": Failed to read magnetometer data.");
+            }
+        }
+
+        int16_t LSM9DS1_Mag::stitch(uint8_t low, uint8_t high) const {
+            return static_cast<int16_t>((high << 8) | low);
+        }
+
+        Vector3 LSM9DS1_Mag::getMagnetometer() const { return magneto; } 
+    } /* namespace Sensors */
+} /* namespace EdgeSense */

--- a/Src/main.cpp
+++ b/Src/main.cpp
@@ -9,7 +9,8 @@
 #include <EdgeSense/Logger/Logger.h>
 #include <EdgeSense/HAL/I2cMaster.h>
 #include <EdgeSense/Sensors/LPS25HB_EnvSens.h>
-#include <EdgeSense/Sensors/LSM9DS1_ImuSens.h>
+#include <EdgeSense/Sensors/LSM9DS1_ImuSensMag.h>
+#include <EdgeSense/Sensors/LSM9DS1_ImuSensAccGyro.h>
 #include <EdgeSense/Sensors/SensorsRegistry.h>
 #include <EdgeSense/Core/ThreadManager.h>
 
@@ -34,29 +35,34 @@ int main() {
 
     /* Create Sensor Instances */
     std::unique_ptr <EnvSensor> Pi_LPS25HB = std::make_unique<LPS25HB>(i2c);
-    std::unique_ptr <ImuSensor> Pi_LSM9DS1 = std::make_unique<LSM9DS1>(i2c);
+    std::unique_ptr <ImuSensor> Pi_LSM9DS1AG = std::make_unique<LSM9DS1_AccGyro>(i2c);
+    std::unique_ptr <ImuSensor> Pi_LSM9DS1Mag = std::make_unique<LSM9DS1_Mag>(i2c);
     
     /* Intialize the LPS25HB */
     if (!Pi_LPS25HB->initialize()) {
         LOG_ERROR("Failed to initialize LPS25HB!");
     }
     /* Intialize the LSM9DS1 */
-    if (!Pi_LSM9DS1->initialize()) {
-        LOG_ERROR("Failed to initialize LSM9DS1!");
+    if (!Pi_LSM9DS1AG->initialize()) {
+        LOG_ERROR("Failed to initialize LSM9DS1 Accelerometer/Gyroscope!");
     }
-
+    if (!Pi_LSM9DS1Mag->initialize()) {
+        LOG_ERROR("Failed to initialize LSM9DS1 Magnetometer!");
+    }
+    
     /* --- 1. Harvester Task (1ms) --- */
     manager.setHarvesterTask([&]() {
         /* Capture the raw data from the I2C sensors */
         Pi_LPS25HB->update(); 
-        Pi_LSM9DS1->update();
+        Pi_LSM9DS1AG->update();
+        Pi_LSM9DS1Mag->update();
 
         /* Push the raw Vector3/float data into the Registry's Circular Buffers */
         auto& registry = EdgeSense::Sensors::SensorRegistry::getInstance();
         
-        registry.getAccelRawBuffer().push(Pi_LSM9DS1->getAcceleration());
-        registry.getGyroRawBuffer().push(Pi_LSM9DS1->getGyroscope());
-        registry.getMagRawBuffer().push(Pi_LSM9DS1->getMagnetometer());
+        registry.getAccelRawBuffer().push(Pi_LSM9DS1AG->getAcceleration());
+        registry.getGyroRawBuffer().push(Pi_LSM9DS1AG->getGyroscope());
+        registry.getMagRawBuffer().push(Pi_LSM9DS1Mag->getMagnetometer());
         
         registry.getPressure().push(Pi_LPS25HB->getPressure());
         registry.getTemperature().push(Pi_LPS25HB->getTemperature());

--- a/Src/main.cpp
+++ b/Src/main.cpp
@@ -34,9 +34,9 @@ int main() {
     }
 
     /* Create Sensor Instances */
-    std::unique_ptr <EnvSensor> Pi_LPS25HB = std::make_unique<LPS25HB>(i2c);
-    std::unique_ptr <ImuSensor> Pi_LSM9DS1AG = std::make_unique<LSM9DS1_AccGyro>(i2c);
-    std::unique_ptr <ImuSensor> Pi_LSM9DS1Mag = std::make_unique<LSM9DS1_Mag>(i2c);
+    std::unique_ptr <EnvSensors> Pi_LPS25HB = std::make_unique<LPS25HB>(i2c);
+    std::unique_ptr <ImuSensors> Pi_LSM9DS1AG = std::make_unique<LSM9DS1_AccGyro>(i2c);
+    std::unique_ptr <ImuSensors> Pi_LSM9DS1Mag = std::make_unique<LSM9DS1_Mag>(i2c);
     
     /* Intialize the LPS25HB */
     if (!Pi_LPS25HB->initialize()) {


### PR DESCRIPTION
Design pattern is kept unchanged even though the the LSM9DS1 is actually two sensors inside one chip
1 physical sensor class = 1 sensor
EnvSensors and ImuSensors abstract all physical sensors below them, while each provide it's own data the interface from the Application side remains the same.

This improve maintainability and extensibility. same classes can be re-used for example for a a weather station development. which sounds like an interesting project :)